### PR TITLE
return an empty map for included if it's null

### DIFF
--- a/src/main/java/com/birbit/jsonapi/JsonApiResponse.java
+++ b/src/main/java/com/birbit/jsonapi/JsonApiResponse.java
@@ -63,7 +63,12 @@ public class JsonApiResponse<T> {
             return Collections.emptyMap();
         }
         //noinspection unchecked
-        return (Map<String, K>) included.get(mapping);
+        Map<String, K> includedMapping = (Map<String, K>) included.get(mapping);
+        if (includedMapping == null) {
+            return Collections.emptyMap();
+        } else {
+            return includedMapping;
+        }
     }
 
     public List<JsonApiError> getErrors() {


### PR DESCRIPTION
getIncluded method is marked with nonNull annotation but returns null. Added a fix to return empty map instead